### PR TITLE
fix: fast path non-docable paths

### DIFF
--- a/docs.ts
+++ b/docs.ts
@@ -570,6 +570,11 @@ class KeyMap<V> extends Map<Key, V> {
   }
 }
 
+/** Determines if a file path can be doc'ed or not. */
+export function isDocable(path: string): boolean {
+  return /\.(ts|tsx|js|jsx|mjs|cjs|mts|cts)$/i.test(path);
+}
+
 function isDocNodeNull(node: DocNode): node is DocNodeNull {
   return node.kind === "null";
 }

--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,7 @@ import {
   generateModuleIndex,
   getDocNodes,
   getImportMapSpecifier,
+  isDocable,
   queryDocNodes,
 } from "./docs.ts";
 import { enqueue } from "./process.ts";
@@ -252,6 +253,9 @@ router.post(
 
 router.get("/v2/modules/:module/:version/doc/:path*", async (ctx) => {
   const { module, version, path } = ctx.params;
+  if (!isDocable(path)) {
+    return;
+  }
   const datastore = await getDatastore();
   const moduleEntryKey = datastore.key(
     ["module", module],


### PR DESCRIPTION
This ensures that requested doc paths for non-docable specifiers are fast pathed, with a 404 returned before doing any database queries.  This will significantly improve the performance of apiland.