### PR TITLE
chore: pause algolia uploads

### DIFF
--- a/docs.ts
+++ b/docs.ts
@@ -487,10 +487,6 @@ export async function generateSymbolIndex(
           path,
           importMap,
         );
-        // Upload docNodes to algolia.
-        if (docNodes.length) {
-          enqueue({ kind: "algolia", module, version, path, docNodes });
-        }
         // if a module doesn't generate any doc nodes, we need to commit a null
         // node to the datastore, see we don't continue to try to generate doc
         // nodes for a module that doesn't export anything.
@@ -961,10 +957,6 @@ export async function getDocNodes(
           path,
           importMap,
         );
-        // Upload docNodes to algolia.
-        if (docNodes.length) {
-          enqueue({ kind: "algolia", module, version, path, docNodes });
-        }
         // if a module doesn't generate any doc nodes, we need to commit a null
         // node to the datastore, see we don't continue to try to generate doc
         // nodes for a module that doesn't export anything.

--- a/main.ts
+++ b/main.ts
@@ -281,10 +281,6 @@ router.get("/v2/modules/:module/:version/doc/:path*", async (ctx) => {
     const importMap = await getImportMapSpecifier(module, version);
     const docNodes = await generateDocNodes(module, version, path, importMap);
     enqueue({ kind: "commit", module, version, path, docNodes });
-    // Upload docNodes to algolia.
-    if (docNodes.length) {
-      enqueue({ kind: "algolia", module, version, path, docNodes });
-    }
     return docNodes;
   } catch (e) {
     if (isHttpError(e)) {


### PR DESCRIPTION
The index is populated with lots of
doc nodes but we need to be particular
about what we want to store in algolia
to increase the quality of search and
reduce infra costs.

I'm pausing the aloglia uploads until
I figure out what we want to store in
aloglia.
