### PR TITLE
fix: symbol index includes subdirs

### DIFF
--- a/specs/api-2.0.0.yaml
+++ b/specs/api-2.0.0.yaml
@@ -955,13 +955,18 @@ components:
         path:
           type: string
           example: /mod.ts
+        kind:
+          type: string
+          enum:
+            - "dir"
+            - "module"
         items:
           type: array
           items:
             $ref: "#/components/schemas/SymbolItem"
       required:
         - "path"
-        - "items"
+        - "kind"
     SymbolItem:
       type: object
       properties:

--- a/types.d.ts
+++ b/types.d.ts
@@ -50,6 +50,7 @@ export interface ModuleEntry {
   path: string;
   type: "file" | "dir";
   size: number;
+  dirs?: string[];
   index?: string[];
 }
 


### PR DESCRIPTION
@crowlKats this "fixes" the symbol endpoint, the only problem is that it required a change to the `module_entry` entity in the datastore to hold onto subdirs of a dir, which means that modules need to be reloaded.  I have reloaded `std@0.148.0` and `std@0.147.0` so we can continue to iterate without reloading everything yet and can go back and do the whole thing later once everything is settled down.