### PR TITLE
feat: add module tags

### DIFF
--- a/docs.ts
+++ b/docs.ts
@@ -311,7 +311,7 @@ export async function checkMaybeLoad(
 
 function getDocPageBase<Kind extends DocPage["kind"]>(
   kind: Kind,
-  { star_count, versions, latest_version }: Module,
+  { star_count, versions, latest_version, tags }: Module,
   { name: module, version, uploaded_at, upload_options, description }:
     ModuleVersion,
   path: string,
@@ -327,6 +327,7 @@ function getDocPageBase<Kind extends DocPage["kind"]>(
     uploaded_at: uploaded_at.toISOString(),
     upload_options,
     star_count,
+    tags,
   };
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -16,10 +16,21 @@ export interface Module {
   description: string;
   versions: string[];
   latest_version: string;
+  /** @deprecated Use `popularity_score` instead. */
   star_count?: number;
   maintenance_score?: number;
+  /** A weighted score of how popular a module is. */
   popularity_score?: number;
   quality_score?: number;
+  /** Tags which are associated with the module. */
+  tags?: ModuleTag[];
+}
+
+/** Defines a "tag" which can be displayed when rending a module or part of a
+ * module. */
+export interface ModuleTag {
+  kind: "popularity";
+  value: string;
 }
 
 /** Stores as kind `module_metrics` in the datastore. */
@@ -87,6 +98,7 @@ export interface DocPageBase {
   };
   /** @deprecated */
   star_count?: number;
+  tags?: ModuleTag[];
 }
 
 interface DocPageDirItem {


### PR DESCRIPTION
This adds `tags` to modules and initially sets a `"popularity"` kind tag which can have one of three values:

- `"Super Popular"` - the top 1% most popular packages
- `"Very Popular"` - the top 2-5% most popular packages
- `"Popular"` - the top 6-10% most popular packages

These tags are returned in the `/page/` responses and when listing modules (`/v2/modules`).