### PR TITLE
fix: ensure doc pages can be stored in datastore

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -15,6 +15,7 @@ import {
   checkMaybeLoad,
   type DocNode,
   type DocNodeKind,
+  entityToDocPage,
   generateDocNodes,
   generateDocPage,
   generateLegacyIndex,
@@ -372,7 +373,7 @@ router.get("/v2/modules/:module/:version/page/:path*{/}?", async (ctx) => {
   const response = await datastore.lookup(indexKey);
   let docPage: DocPage | undefined;
   if (response.found) {
-    docPage = entityToObject<DocPage>(response.found[0].entity);
+    docPage = entityToDocPage(response.found[0].entity);
   } else {
     docPage = await generateDocPage(
       datastore,


### PR DESCRIPTION
Datastore only allows a 20 level depth of nesting objects, sometimes, doc nodes are deeper than that, requiring that we serialise the definitions of doc nodes so they can be stored, and the deserialise them for the client.