### PR TITLE
feat: add headers on redirect

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -425,6 +425,9 @@ router.get("/v2/modules/:module/:version/page/:path*{/}?", async (ctx) => {
       headers: {
         location:
           `/v2/modules/${module}/${version}/page${docPage.path}${ctx.url().search}`,
+        "X-Deno-Module": module,
+        "X-Deno-Version": version,
+        "X-Deno-Module-Path": docPage.path,
       },
     });
   } else {

--- a/modules.ts
+++ b/modules.ts
@@ -169,7 +169,11 @@ export async function redirectToLatest(
   return new Response(null, {
     status: 302,
     statusText: "Found",
-    headers: { location },
+    headers: {
+      location,
+      "X-Deno-Module": module,
+      "X-Deno-Latest-Version": latest,
+    },
   });
 }
 

--- a/specs/api-2.0.0.yaml
+++ b/specs/api-2.0.0.yaml
@@ -217,6 +217,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ModuleVersion"
+        "302":
+          description: >
+            Found - The latest version has been found. This is sent when 
+            `__latest__` is used as the version.
+          headers:
+            Location:
+              schema:
+                type: string
+            X-Deno-Module:
+              schema:
+                $ref: "#/components/schemas/ModuleName"
+            X-Deno-Latest-Version:
+              schema:
+                type: string
         "404":
           description: Not found - the requested resource was not found
           content:
@@ -563,6 +577,35 @@ paths:
               schema:
                 $ref: "#/components/schemas/HttpError"
             text/html:
+              schema:
+                type: string
+        "301":
+          description: Moved - This page has a different location
+          headers:
+            Location:
+              schema:
+                type: string
+            X-Deno-Module:
+              schema:
+                $ref: "#/components/schemas/ModuleName"
+            X-Deno-Version:
+              schema:
+                type: string
+            X-Deno-Path:
+              schema:
+                type: string
+        "302":
+          description: >
+            Found - The latest version has been found. This is sent when 
+            `__latest__` is used as the version.
+          headers:
+            Location:
+              schema:
+                type: string
+            X-Deno-Module:
+              schema:
+                $ref: "#/components/schemas/ModuleName"
+            X-Deno-Latest-Version:
               schema:
                 type: string
         "404":


### PR DESCRIPTION
When using `__latest__` in the version via a 302, the following headers will be set:

- `X-Deno-Module` - the module that was found
- `X-Deno-Latest-Version` - the latest version of that module that was found

When getting redirected on the `/page/` endpoint via a 301:

- `X-Deno-Module` - the module name
- `X-Deno-Version` - the version name
- `X-Deno-Module-Path` - the destination path
