### PR TITLE
fix: update code page dir entries

### DIFF
--- a/docs.ts
+++ b/docs.ts
@@ -48,6 +48,7 @@ import { getDatastore } from "./store.ts";
 import type {
   CodePage,
   CodePageDir,
+  CodePageDirEntry,
   CodePageFile,
   DocPage,
   DocPageFile,
@@ -506,15 +507,16 @@ async function getCodePageDir(
       ["module", module.name],
       ["module_version", version.version],
     ));
-  const entries: ModuleEntry[] = [];
+  const entries: CodePageDirEntry[] = [];
   for await (const entity of datastore.streamQuery(query)) {
-    const moduleEntry = entityToObject<ModuleEntry>(entity);
-    console.log(path, moduleEntry.path);
+    const { type: kind, size, docable, path } = entityToObject<ModuleEntry>(
+      entity,
+    );
     if (
-      moduleEntry.path.startsWith(path) &&
-      moduleEntry.path.slice(path.length).lastIndexOf("/") <= 0
+      path.startsWith(path) &&
+      path.slice(path.length).lastIndexOf("/") <= 0
     ) {
-      entries.push(moduleEntry);
+      entries.push({ path, kind, size, docable });
     }
   }
   codePage.entries = entries;

--- a/specs/api-2.0.0.yaml
+++ b/specs/api-2.0.0.yaml
@@ -898,6 +898,36 @@ components:
         - $ref: "#/components/schemas/PageBase"
         - type: object
           properties:
+            entries:
+              type: array
+              items:
+                $ref: "#/components/schemas/CodePageDirEntry"
+          required:
+            - "entries"
+    CodePageDirEntry:
+      type: object
+      properties:
+        path:
+          type: string
+          example: /mod.ts
+        kind:
+          type: string
+          enum:
+            - file
+            - dir
+        size:
+          type: number
+        docable:
+          type: boolean
+      required:
+        - "path"
+        - "kind"
+        - "size"
+    CodePageFile:
+      allOf:
+        - $ref: "#/components/schemas/PageBase"
+        - type: object
+          properties:
             size:
               type: number
               example: 27234
@@ -905,17 +935,6 @@ components:
               type: boolean
           required:
             - "size"
-    CodePageFile:
-      allOf:
-        - $ref: "#/components/schemas/PageBase"
-        - type: object
-          properties:
-            entries:
-              type: array
-              items:
-                $ref: "#/components/schemas/ModuleEntry"
-          required:
-            - "entries"
     DocNode:
       type: object
       properties:
@@ -1044,26 +1063,6 @@ components:
             - "nav"
             - "name"
             - "docNodes"
-    File:
-      type: object
-      properties:
-        path:
-          type: string
-          example: /mod.ts
-        size:
-          type: number
-          format: int64
-          example: 3454
-        type:
-          type: string
-          enum:
-            - file
-            - dir
-          example: file
-        raw_url:
-          type: string
-          format: uri
-          example: "https://api.deno.land/modules/oak/v10.0.1/raw/mod.ts"
     HttpError:
       type: object
       properties:
@@ -1175,31 +1174,6 @@ components:
         - latest_version
         - versions
       description: Representation of a module
-    ModuleEntry:
-      type: object
-      properties:
-        path:
-          type: string
-          example: /mod.ts
-        type:
-          type: string
-          enum:
-            - file
-            - dir
-        size:
-          type: number
-        default:
-          type: string
-        dirs:
-          type: array
-          items:
-            type: string
-        docable:
-          type: boolean
-        index:
-          type: array
-          items:
-            type: string
     ModuleMetricList:
       allOf:
         - $ref: "#/components/schemas/ListBase"

--- a/types.d.ts
+++ b/types.d.ts
@@ -187,9 +187,17 @@ export interface CodePageFile extends PageBase {
   docable?: boolean;
 }
 
+export interface CodePageDirEntry {
+  path: string;
+  kind: "file" | "dir";
+  size: number;
+  /** Indicates if the page is docable or not. */
+  docable?: boolean;
+}
+
 export interface CodePageDir extends PageBase {
   kind: "dir";
-  entries: ModuleEntry[];
+  entries: CodePageDirEntry[];
 }
 
 export type CodePage =


### PR DESCRIPTION
Mainly this changes the `type` to `kind` for the `CodePageDir.entries` response.