### PR TITLE
fix: doc page caching

### DIFF
--- a/cache.ts
+++ b/cache.ts
@@ -397,7 +397,10 @@ export function cacheDocPage(
           cachedDocPages.set(entryItem, new Map());
         }
         const docPages = cachedDocPages.get(entryItem)!;
-        docPages.set(symbol, docPage);
+        // the original doc page can get partially serialized after added to
+        // the cache, which causes problems when revisiting the page in the
+        // same isolate, so we do a structured clone when caching here.
+        docPages.set(symbol, structuredClone(docPage));
         cachedModuleNames.add(module);
       }
     }


### PR DESCRIPTION
This fixes the issue where when a doc page is generated and contains doc nodes, the cached version becomes serialised, causing subsequent renders of the same page to fail in the same isolate.