### PR TITLE
fix: add page no versions and allow modules with no versions

### DIFF
--- a/docs.ts
+++ b/docs.ts
@@ -322,6 +322,7 @@ function getPageBase<Kind extends DocPage["kind"] | CodePage["kind"]>(
     ModuleVersion,
   path: string,
 ): PageBase & { kind: Kind } {
+  assert(latest_version);
   return {
     kind,
     module,
@@ -472,6 +473,7 @@ function getPagePathNotFound(
 function getPageInvalidVersion(
   { name: module, description, versions, latest_version }: Module,
 ): PageInvalidVersion {
+  assert(latest_version);
   return {
     kind: "invalid-version",
     module,

--- a/types.d.ts
+++ b/types.d.ts
@@ -15,7 +15,7 @@ export interface Module {
   name: string;
   description: string;
   versions: string[];
-  latest_version: string;
+  latest_version: string | null;
   /** @deprecated Use `popularity_score` instead. */
   star_count?: number;
   maintenance_score?: number;
@@ -95,7 +95,7 @@ export interface PageBase {
   versions: string[];
   latest_version: string;
   uploaded_at: string;
-  upload_options: {
+  upload_options?: {
     type: string;
     repository: string;
     ref: string;
@@ -165,6 +165,11 @@ export interface PagePathNotFound extends PageBase {
   kind: "notfound";
 }
 
+export interface PageNoVersions {
+  kind: "no-versions";
+  module: string;
+}
+
 export interface PageInvalidVersion {
   kind: "invalid-version";
   module: string;
@@ -180,6 +185,7 @@ export type DocPage =
   | DocPageIndex
   | DocPageFile
   | PageInvalidVersion
+  | PageNoVersions
   | PagePathNotFound
   | DocPageRedirect;
 
@@ -207,4 +213,5 @@ export type CodePage =
   | CodePageFile
   | CodePageDir
   | PageInvalidVersion
+  | PageNoVersions
   | PagePathNotFound;


### PR DESCRIPTION
This provides a `PageNoVersions` response when the `__latest__` version of the module is requested on `/pages/doc` or `/pages/code` and there are no versions available.  It also adjust the schema to allow modules without any unpublished versions to exist.