### PR TITLE
feat: add badge endpoints

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -475,6 +475,7 @@ router.get("/shields/:module/version", async (ctx) => {
     return {
       schemaVersion: 1,
       label: "deno.land/x",
+      namedLogo: "deno",
       message: moduleItem.latest_version,
       color: "informational",
     };
@@ -507,6 +508,7 @@ router.get("/shields/:module/popularity", async (ctx) => {
     return {
       schemaVersion: 1,
       label: "deno.land/x",
+      namedLogo: "deno",
       message,
       color,
     };

--- a/specs/api-2.0.0.yaml
+++ b/specs/api-2.0.0.yaml
@@ -1426,6 +1426,9 @@ components:
         message:
           type: string
           example: v1.0.0
+        namedLogo:
+          type: string
+          example: deno
         color:
           type: string
           example: informational


### PR DESCRIPTION
This adds two endpoints... `/shields/:module/version` and `/shields/:module/popularity` which provide JSON payloads which can be used with https://sheilds.io/ to generate badges.

Example for fresh:

[![Popularity](https://img.shields.io/endpoint?url=https%3A%2F%2Fapiland-01ns5605w6vg.deno.dev%2Fshields%2Ffresh%2Fpopularity)](https://deno.land/x/fresh)

[![Latest Version](https://img.shields.io/endpoint?url=https%3A%2F%2Fapiland-01ns5605w6vg.deno.dev%2Fshields%2Ffresh%2Fversion)](https://deno.land/x/fresh)

Example for esbuild:

[![Popularity](https://img.shields.io/endpoint?url=https%3A%2F%2Fapiland-01ns5605w6vg.deno.dev%2Fshields%2Fesbuild%2Fpopularity)](https://deno.land/x/esbuild)

[![Latest Version](https://img.shields.io/endpoint?url=https%3A%2F%2Fapiland-01ns5605w6vg.deno.dev%2Fshields%2Fesbuild%2Fversion)](https://deno.land/x/esbuild)

Example for lume:

[![Popularity](https://img.shields.io/endpoint?url=https%3A%2F%2Fapiland-01ns5605w6vg.deno.dev%2Fshields%2Flume%2Fpopularity)](https://deno.land/x/lume)

[![Latest Version](https://img.shields.io/endpoint?url=https%3A%2F%2Fapiland-01ns5605w6vg.deno.dev%2Fshields%2Flume%2Fversion)](https://deno.land/x/lume)

Example for disordeno:

[![Popularity](https://img.shields.io/endpoint?url=https%3A%2F%2Fapiland-01ns5605w6vg.deno.dev%2Fshields%2Fdiscordeno%2Fpopularity)](https://deno.land/x/discordeno)

[![Latest Version](https://img.shields.io/endpoint?url=https%3A%2F%2Fapiland-01ns5605w6vg.deno.dev%2Fshields%2Fdiscordeno%2Fversion)](https://deno.land/x/discordeno)

Example for supabase:

[![Popularity](https://img.shields.io/endpoint?url=https%3A%2F%2Fapiland-01ns5605w6vg.deno.dev%2Fshields%2Fsupabase%2Fpopularity)](https://deno.land/x/supabase)

[![Latest Version](https://img.shields.io/endpoint?url=https%3A%2F%2Fapiland-01ns5605w6vg.deno.dev%2Fshields%2Fsupabase%2Fversion)](https://deno.land/x/supabase)