### PR TITLE
feat: add symbols to module and symbol doc pages

### DIFF
--- a/cache.ts
+++ b/cache.ts
@@ -288,7 +288,13 @@ export async function lookupDocPage(
             break;
           }
           case "doc_page": {
-            foundModuleDocPage = docPageItem = entityToDocPage(entity);
+            const docPage = entityToDocPage(entity);
+            if (
+              !((docPage.kind === "module" || docPage.kind === "symbol") &&
+                !docPage.symbols)
+            ) {
+              foundModuleDocPage = docPageItem = entityToDocPage(entity);
+            }
             break;
           }
           default:

--- a/main.ts
+++ b/main.ts
@@ -33,7 +33,6 @@ import {
   generateInfoPage,
   generateModuleIndex,
   generateSourcePage,
-  generateSymbolIndex,
   getDocNodes,
   getImportMapSpecifier,
   isDocable,
@@ -485,29 +484,6 @@ router.get("/v2/modules/:module/:version/index/:path*{/}?", async (ctx) => {
   const index = await generateModuleIndex(datastore, module, version, path);
   if (index) {
     enqueue({ kind: "commitIndex", module, version, path, index });
-  }
-  return index;
-});
-
-router.get("/v2/modules/:module/:version/symbols/:path*{/}?", async (ctx) => {
-  const { module, version, path: paramPath } = ctx.params;
-  if (version === "__latest__") {
-    return redirectToLatest(ctx.url(), module);
-  }
-  const path = `/${paramPath}`;
-  datastore = datastore ?? await getDatastore();
-  const indexKey = datastore.key(
-    ["module", module],
-    ["module_version", version],
-    ["symbol_index", path],
-  );
-  const response = await datastore.lookup(indexKey);
-  if (response.found) {
-    return entityToObject(response.found[0].entity);
-  }
-  const index = await generateSymbolIndex(datastore, module, version, path);
-  if (index) {
-    enqueue({ kind: "commitSymbolIndex", module, version, path, index });
   }
   return index;
 });

--- a/modules.ts
+++ b/modules.ts
@@ -205,8 +205,8 @@ const MODULE_KINDS = [
 const VERSION_KINDS = [
   "doc_node",
   "module_index",
-  "symbol_index",
   "nav_index",
+  "symbol_index",
 ];
 
 export async function clearAppend(

--- a/process.ts
+++ b/process.ts
@@ -27,7 +27,6 @@ import {
   isDocable,
   type LegacyIndex,
   type ModuleIndex,
-  type SymbolIndex,
 } from "./docs.ts";
 import {
   clearModule,
@@ -47,6 +46,7 @@ import type {
   Module,
   ModuleVersion,
   SourcePage,
+  SymbolIndexItem,
 } from "./types.d.ts";
 import { assert } from "./util.ts";
 
@@ -109,15 +109,12 @@ interface CommitMutations extends TaskBase {
   mutations: Mutation[];
 }
 
-interface SymbolIndexBase {
+interface CommitSymbolIndexTask extends TaskBase {
+  kind: "commitSymbolIndex";
   module: string;
   version: string;
   path: string;
-  index: SymbolIndex;
-}
-
-interface CommitSymbolIndexTask extends TaskBase, SymbolIndexBase {
-  kind: "commitSymbolIndex";
+  items: SymbolIndexItem[];
 }
 
 interface CommitNavTask extends TaskBase {
@@ -261,20 +258,6 @@ async function taskCommitMutations(id: number, { mutations }: CommitMutations) {
   }
 }
 
-function taskCommitSymbolIndex(
-  id: number,
-  { module, version, path, index }: CommitSymbolIndexTask,
-) {
-  console.log(
-    `[${id}]: %cCommitting%c symbol index for %c"${module}@${version}${path}"%c...`,
-    "color:green",
-    "color:none",
-    "color:cyan",
-    "color:none",
-  );
-  return commitSymbolIndex(id, module, version, path, index);
-}
-
 function taskCommitCodePage(
   id: number,
   { module, version, path, sourcePage }: CommitSourcePageTask,
@@ -301,6 +284,20 @@ function taskCommitDocPage(
     "color:none",
   );
   return commitDocPage(id, module, version, path, symbol, docPage);
+}
+
+function taskCommitSymbolIndex(
+  id: number,
+  { module, version, path, items }: CommitSymbolIndexTask,
+) {
+  console.log(
+    `[${id}]: %cCommitting%c symbol index for %c"${module}@${version}${path}"%c...`,
+    "color:green",
+    "color:none",
+    "color:cyan",
+    "color:none",
+  );
+  return commitSymbolIndex(id, module, version, path, items);
 }
 
 function taskCommitNav(
@@ -549,14 +546,14 @@ function process(id: number, task: TaskDescriptor): Promise<void> {
       return taskCommitLegacyIndex(id, task);
     case "commitMutations":
       return taskCommitMutations(id, task);
-    case "commitSymbolIndex":
-      return taskCommitSymbolIndex(id, task);
     case "commitSourcePage":
       return taskCommitCodePage(id, task);
     case "commitDocPage":
       return taskCommitDocPage(id, task);
     case "commitNav":
       return taskCommitNav(id, task);
+    case "commitSymbolIndex":
+      return taskCommitSymbolIndex(id, task);
     case "load":
       return taskLoadModule(id, task);
     default:

--- a/specs/api-2.0.0.yaml
+++ b/specs/api-2.0.0.yaml
@@ -659,86 +659,6 @@ paths:
             text/html:
               schema:
                 type: string
-  /v2/modules/{module}/{version}/symbols:
-    get:
-      tags:
-        - registry
-      summary: Get a map of symbols by module.
-      description: >
-        Responds with an array which contains code modules and exported symbol
-        information for each code module in the root path.
-      operationId: getModuleSymbols
-      parameters:
-        - name: module
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/ModuleName"
-        - name: version
-          in: path
-          required: true
-          schema:
-            type: string
-            example: v10.0.1
-      responses:
-        "200":
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SymbolIndex"
-        "404":
-          description: Not found - the requested resource was not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HttpError"
-            text/html:
-              schema:
-                type: string
-  /v2/modules/{module}/{version}/symbols/{path}:
-    get:
-      tags:
-        - registry
-      summary: Get a map of symbols by module for a subpath.
-      description: >
-        Responds with an array which contains code modules and exported symbol
-        information for each code module in the specified sub-path.
-      operationId: getModuleSymbolsPath
-      parameters:
-        - name: module
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/ModuleName"
-        - name: version
-          in: path
-          required: true
-          schema:
-            type: string
-            example: v10.0.1
-        - name: path
-          in: path
-          required: true
-          schema:
-            type: string
-            example: src
-      responses:
-        "200":
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SymbolIndex"
-        "404":
-          description: Not found - the requested resource was not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HttpError"
-            text/html:
-              schema:
-                type: string
   /v2/pages/mod/source/{module}/{version}:
     get:
       tags:
@@ -1228,6 +1148,12 @@ components:
       type: http
       scheme: bearer
   schemas:
+    DeclarationKind:
+      type: string
+      enum:
+        - private
+        - export
+        - declare
     DependencyError:
       type: object
       properties:
@@ -1428,6 +1354,10 @@ components:
                 $ref: "#/components/schemas/DocPageNavItem"
             docNodes:
               $ref: "#/components/schemas/DocNodeArray"
+            symbols:
+              type: array
+              items:
+                $ref: "#/components/schemas/SymbolIndexItem"
           required:
             - "nav"
             - "docNodes"
@@ -1471,6 +1401,10 @@ components:
               example: "AClass"
             docNodes:
               $ref: "#/components/schemas/DocNodeArray"
+            symbols:
+              type: array
+              items:
+                $ref: "#/components/schemas/SymbolIndexItem"
           required:
             - "nav"
             - "name"
@@ -2089,33 +2023,22 @@ components:
         - "submodule"
         - "updated"
         - "popularity"
-    SymbolIndex:
-      type: object
-      properties:
-        items:
-          type: array
-          items:
-            $ref: "#/components/schemas/SymbolIndexItem"
-      required:
-        - "items"
     SymbolIndexItem:
       type: object
       properties:
-        path:
+        name:
           type: string
-          example: /mod.ts
         kind:
+          $ref: "#/components/schemas/DocNodeKind"
+        declarationKind:
+          $ref: "#/components/schemas/DeclarationKind"
+        filename:
           type: string
-          enum:
-            - "dir"
-            - "module"
-        items:
-          type: array
-          items:
-            $ref: "#/components/schemas/SymbolItem"
       required:
-        - "path"
+        - "name"
         - "kind"
+        - "declarationKind"
+        - "filename"
     SymbolItem:
       type: object
       properties:

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,11 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
-import type { DocNode, DocNodeKind, JsDoc } from "deno_doc/types";
+import type {
+  DeclarationKind,
+  DocNode,
+  DocNodeKind,
+  JsDoc,
+} from "deno_doc/types";
 import type { patterns } from "./analysis.ts";
 
 /**
@@ -226,12 +231,14 @@ export interface DocPageSymbol extends PageBase {
   nav: DocPageNavItem[];
   name: string;
   docNodes: DocNode[];
+  symbols?: SymbolIndexItem[];
 }
 
 export interface DocPageModule extends PageBase {
   kind: "module";
   nav: DocPageNavItem[];
   docNodes: DocNode[];
+  symbols?: SymbolIndexItem[];
 }
 
 export interface DocPageIndex extends PageBase {
@@ -368,3 +375,14 @@ export type SourcePage =
   | PageInvalidVersion
   | PageNoVersions
   | PagePathNotFound;
+
+export interface SymbolIndex {
+  items: SymbolIndexItem[];
+}
+
+export interface SymbolIndexItem {
+  name: string;
+  kind: DocNodeKind;
+  declarationKind: DeclarationKind;
+  filename: string;
+}


### PR DESCRIPTION
This is needed to make symbol linking in dotland work properly.  It adds an index of symbols, with flatten namespaces, that are within the scope of the module.  This will allow docland to determine if it can link to the symbol within the module.