### PR TITLE
feat: add global symbol endpoint

### DIFF
--- a/cache.ts
+++ b/cache.ts
@@ -4,8 +4,10 @@ import { type Datastore, entityToObject } from "google_datastore";
 import type { Entity, Key } from "google_datastore/types";
 import { entityToDocPage, hydrateDocNodes } from "./docs.ts";
 import { getDatastore } from "./store.ts";
-import type {
+import {
   DocPage,
+  GlobalSymbolItem,
+  GlobalSymbols,
   InfoPage,
   LibDocPage,
   Library,
@@ -491,6 +493,26 @@ export async function lookupLibDocPage(
     }
   }
   return docPageItem;
+}
+
+let globalSymbols: GlobalSymbolItem[] | undefined;
+
+export async function lookupGlobalSymbols() {
+  if (globalSymbols) {
+    return globalSymbols;
+  }
+  datastore = datastore ?? await getDatastore();
+  const res = await datastore.lookup(datastore.key(
+    ["global_symbols", "$$root$$"],
+  ));
+  if (!res.found || res.found.length !== 1) {
+    throw new Error(
+      "Unexpected result returned from datastore.",
+      { cause: res },
+    );
+  }
+  const { items } = entityToObject<GlobalSymbols>(res.found[0].entity);
+  return globalSymbols = items;
 }
 
 export async function lookup(

--- a/main.ts
+++ b/main.ts
@@ -20,6 +20,7 @@ import {
   cacheSourcePage,
   lookup,
   lookupDocPage,
+  lookupGlobalSymbols,
   lookupInfoPage,
   lookupLibDocPage,
   lookupSourcePage,
@@ -114,6 +115,7 @@ router.all("/", () =>
           <li><code>/v2/modules/:module</code> - Provide information about a specific module - [<a href="/v2/modules/std" target="_blank">example</a>]</li>
           <li><code>/v2/modules/:module/:version</code> - Provide information about a specific module version - [<a href="/v2/modules/std/0.139.0" target="_blank">example</a>]</li>
           <li><code>/v2/modules/:module/:version/doc/:path*</code> - Provide documentation nodes for a specific path of a specific module version -  [<a href="/v2/modules/std/0.139.0/doc/archive/tar.ts" target="_blank">example</a>]</li>
+          <li><code>/v2/symbols/global</code> - Provide a list of symbols that are in the global scope of the Deno CLI runtime - [<a href="/v2/symbols/global" target="_blank">example</a>]</li>
           <li><code>/ping</code> - A health endpoint for the server - [<a href="/ping" target="_blank">example</a>]</li>
         <ul>
       </div>
@@ -464,6 +466,8 @@ router.get("/v2/modules/:module/:version/doc/:path*", async (ctx) => {
     return undefined;
   }
 });
+
+router.get("/v2/symbols/global", (_ctx) => lookupGlobalSymbols());
 
 router.get("/v2/modules/:module/:version/index/:path*{/}?", async (ctx) => {
   const { module, version, path: paramPath } = ctx.params;

--- a/specs/api-2.0.0.yaml
+++ b/specs/api-2.0.0.yaml
@@ -1026,6 +1026,33 @@ paths:
             text/html:
               schema:
                 type: string
+  /v2/symbols/global:
+    get:
+      tags:
+        - symbols
+      summary: Get global symbol information
+      description: >
+        Return an array of global symbol items which can be used to determine
+        what symbols are in the scope of Deno CLI's runtime environment.
+      operationId: getGlobalSymbols
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/GlobalSymbolItem"
+        "404":
+          description: Not found - the requested resource was not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HttpError"
+            text/html:
+              schema:
+                type: string
   /shields/{module}/popularity:
     get:
       tags:
@@ -1409,6 +1436,21 @@ components:
             - "nav"
             - "name"
             - "docNodes"
+    GlobalSymbolItem:
+      type: object
+      properties:
+        name: 
+          type: string
+        library:
+          type: string
+          enum:
+            - "deno"
+            - "esnext"
+        unstable:
+          type: boolean
+      required:
+        - "name"
+        - "library"
     HttpError:
       type: object
       properties:

--- a/types.d.ts
+++ b/types.d.ts
@@ -16,6 +16,16 @@ import type { patterns } from "./analysis.ts";
 
 export type { DocNode } from "deno_doc/types";
 
+export interface GlobalSymbolItem {
+  name: string;
+  library: "deno" | "esnext";
+  unstable?: boolean;
+}
+
+export interface GlobalSymbols {
+  items: GlobalSymbolItem[];
+}
+
 export interface Library {
   name: string;
   versions: string[];


### PR DESCRIPTION
This adds `/v2/symbols/global` which will return an index of in scope globals for the Deno CLI runtime, which will allow us to provide links from third party modules and `std` to built-in APIs.