### PR TITLE
feat: add registry completion endpoints

### DIFF
--- a/algolia.ts
+++ b/algolia.ts
@@ -8,7 +8,7 @@
 
 import { type MultipleBatchRequest } from "@algolia/client-search";
 import { createFetchRequester } from "@algolia/requester-fetch";
-import algoliasearch, { SearchClient } from "algoliasearch";
+import algoliasearch, { type SearchClient } from "algoliasearch";
 import dax from "dax";
 import { JsDocTagTags } from "deno_doc/types";
 import { type Datastore, objectGetKey } from "google_datastore";
@@ -30,6 +30,7 @@ const ALLOWED_DOC_KINDS: DocNodeKind[] = [
 
 let datastore: Datastore | undefined;
 let denoLandApp: SearchClient | undefined;
+let searchOnlyClient: SearchClient | undefined;
 let uid = 0;
 
 export enum Source {
@@ -232,6 +233,20 @@ async function getDenoLandApp(): Promise<SearchClient> {
   return denoLandApp = algoliasearch(
     algoliaKeys.appId,
     algoliaKeys.apiKey,
+    { requester },
+  );
+}
+
+/** Resolves with a search only client against algolia */
+export async function getSearchClient(): Promise<SearchClient> {
+  if (searchOnlyClient) {
+    return searchOnlyClient;
+  }
+  const requester = createFetchRequester();
+  await readyPromise;
+  return searchOnlyClient = algoliasearch(
+    algoliaKeys.appId,
+    algoliaKeys.searchApiKey,
     { requester },
   );
 }

--- a/auth.ts
+++ b/auth.ts
@@ -26,7 +26,7 @@ export let keys: {
   project_id: string;
 };
 /** Algolia credentials required to upload docNodes to algolia. */
-export let algoliaKeys: { appId: string; apiKey: string };
+export let algoliaKeys: { appId: string; apiKey: string; searchApiKey: string };
 
 let readyResolve: (value?: unknown) => void;
 
@@ -51,6 +51,7 @@ export const readyPromise = new Promise((res) => readyResolve = res);
   algoliaKeys = {
     appId: Deno.env.get("ALGOLIA_APP_ID") ?? "",
     apiKey: Deno.env.get("ALGOLIA_API_KEY") ?? "",
+    searchApiKey: Deno.env.get("ALGOLIA_SEARCH_API_KEY") ?? "",
   };
 })();
 

--- a/completions.ts
+++ b/completions.ts
@@ -1,0 +1,213 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+/**
+ * Utility functions related to completions.
+ *
+ * @module
+ */
+
+import type { DocNodeModuleDoc } from "deno_doc/types";
+
+import {
+  type Datastore,
+  entityToObject,
+  objectSetKey,
+  objectToEntity,
+} from "google_datastore";
+import { getDatastore } from "./auth.ts";
+import { lookup } from "./cache.ts";
+import { kinds } from "./consts.ts";
+import { enqueue } from "./process.ts";
+import type {
+  ModuleEntry,
+  PathCompletion,
+  PathCompletions,
+} from "./types.d.ts";
+import { assert } from "./util.ts";
+
+const completionCache = new Map<string, PathCompletions>();
+
+function isImportable(path: string) {
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|json)$/i.test(path);
+}
+
+function isHidden(path: string) {
+  return /\/\./.test(path);
+}
+
+function hasModules(
+  map: Map<string, PathCompletion>,
+  entry: PathCompletion,
+): boolean {
+  if (entry.modules.length) {
+    return true;
+  }
+  if (entry.dirs) {
+    for (const dir of entry.dirs) {
+      const e = map.get(dir);
+      if (e) {
+        return hasModules(map, e);
+      }
+    }
+  }
+  return false;
+}
+
+function toCompletions(
+  module: string,
+  version: string,
+  entries: ModuleEntry[],
+): PathCompletions {
+  const completionMap = new Map<string, PathCompletion>();
+  for (const entry of entries) {
+    if (isHidden(entry.path)) {
+      continue;
+    }
+    if (entry.type === "dir") {
+      let path = entry.path;
+      if (path !== "/") {
+        path = `${path}/`;
+      }
+      if (!completionMap.has(path)) {
+        completionMap.set(path, {
+          path,
+          default: entry.default,
+          dirs: entry.dirs?.map((p) => `${p}/`),
+          modules: [],
+        });
+      }
+    } else {
+      if (isImportable(entry.path)) {
+        const parts = entry.path.split("/");
+        parts.pop();
+        const parent = `${parts.join("/")}/`;
+        const completionItem = completionMap.get(parent);
+        if (!completionItem) {
+          console.error("Missing parent:", parent);
+          continue;
+        }
+        completionItem.modules.push({ path: entry.path });
+      }
+    }
+  }
+  const items: PathCompletion[] = [];
+  for (const value of completionMap.values()) {
+    if (hasModules(completionMap, value)) {
+      items.push(value);
+    }
+  }
+  return { name: module, version, items };
+}
+
+let datastore: Datastore | undefined;
+
+/** Resolve with a collection of directories and paths for a module and version
+ * for building completion items. */
+export async function getCompletions(
+  module: string,
+  version: string,
+): Promise<PathCompletions | undefined> {
+  if (version === "__latest__") {
+    const [moduleItem] = await lookup(module);
+    if (!moduleItem || !moduleItem.latest_version) {
+      return;
+    }
+    version = moduleItem.latest_version;
+  }
+  const key = `${module}@${version}`;
+  let pathCompletions = completionCache.get(key);
+  if (!pathCompletions) {
+    datastore = datastore ?? await getDatastore();
+    const res = await datastore.lookup(datastore.key(
+      [kinds.MODULE_KIND, module],
+      [kinds.PATH_COMPLETIONS_KIND, version],
+    ));
+    if (res.found && res.found.length === 1) {
+      const [{ entity }] = res.found;
+      pathCompletions = entityToObject(entity);
+      completionCache.set(key, pathCompletions);
+    }
+    if (!pathCompletions) {
+      const entries = await datastore.query<ModuleEntry>(
+        datastore.createQuery(kinds.MODULE_ENTRY_KIND).hasAncestor(
+          datastore.key(
+            [kinds.MODULE_KIND, module],
+            [kinds.MODULE_VERSION_KIND, version],
+          ),
+        ),
+      );
+      if (entries.length) {
+        pathCompletions = toCompletions(module, version, entries);
+        objectSetKey(
+          pathCompletions,
+          datastore.key(
+            [kinds.MODULE_KIND, module],
+            [kinds.PATH_COMPLETIONS_KIND, version],
+          ),
+        );
+        completionCache.set(key, pathCompletions);
+        enqueue({
+          kind: "commitMutations",
+          mutations: [{ upsert: objectToEntity(pathCompletions) }],
+        });
+      }
+    }
+  }
+  return pathCompletions;
+}
+
+async function getModDoc(
+  module: string,
+  version: string,
+  path: string,
+): Promise<string> {
+  datastore = datastore ?? await getDatastore();
+  const docNodeQuery = datastore
+    .createQuery(kinds.DOC_NODE_KIND)
+    .filter("kind", "moduleDoc")
+    .hasAncestor(datastore.key(
+      [kinds.MODULE_KIND, module],
+      [kinds.MODULE_VERSION_KIND, version],
+      [kinds.MODULE_ENTRY_KIND, path],
+    ));
+  for await (const entity of datastore.streamQuery(docNodeQuery)) {
+    assert(entity.key);
+    // this ensure we only find moduleDoc for the module, not from a re-exported
+    // namespace which might have module doc as well.
+    if (entity.key.path.length !== 4) {
+      continue;
+    }
+    const obj = entityToObject<DocNodeModuleDoc>(entity);
+    return obj.jsDoc.doc ?? "";
+  }
+  return "";
+}
+
+/** Attempt to resolve any JSDoc associated with a path. */
+export async function getPathDoc(
+  completions: PathCompletions,
+  dir: string,
+  path: string,
+): Promise<string | undefined> {
+  const pathCompletion = completions.items.find(({ path }) => path === dir);
+  if (pathCompletion) {
+    const search = path === dir ? pathCompletion.default : path;
+    if (search) {
+      const mod = pathCompletion.modules.find(({ path }) => path === search);
+      if (mod) {
+        if (mod.doc == null) {
+          mod.doc = await getModDoc(
+            completions.name,
+            completions.version,
+            search,
+          );
+          enqueue({
+            kind: "commitMutations",
+            mutations: [{ upsert: objectToEntity(completions) }],
+          });
+        }
+        return mod.doc || "";
+      }
+    }
+  }
+}

--- a/consts.ts
+++ b/consts.ts
@@ -55,6 +55,8 @@ export const kinds = {
   MODULE_VERSION_KIND: "module_version",
   /** A cached version of the navigation index for a module dir. */
   NAV_INDEX_KIND: "nav_index",
+  /** A cached version of an index of paths used for generating completions. */
+  PATH_COMPLETIONS_KIND: "path_completions",
   /** Represents dependency metric information by source type. */
   SOURCE_METRIC_KIND: "dependency_metrics",
   /** Metrics for a submodule. */

--- a/import-map.json
+++ b/import-map.json
@@ -15,6 +15,7 @@
     "import_map": "https://raw.githubusercontent.com/denoland/import_map/main/mod.ts",
     "jsonc-parser": "https://esm.sh/jsonc-parser@3.1.0?pin=v90",
     "std/": "https://deno.land/std@0.159.0/",
+    "twas": "https://esm.sh/twas@2.1.2?pin=v90",
     "https://deno.land/x/jose@v4.8.1/": "https://deno.land/x/jose@v4.9.2/",
     "https://deno.land/std@0.151.0/": "https://deno.land/std@0.159.0/",
     "https://deno.land/std@0.152.0/": "https://deno.land/std@0.159.0/",

--- a/main.ts
+++ b/main.ts
@@ -796,20 +796,18 @@ router.get("/completions/resolve/:mod/:ver/:path*{/}?", async (ctx) => {
     const parts = path.split("/");
     const last = parts.pop();
     const dir = last ? `${parts.join("/")}/` : path;
-    let value = await getPathDoc(completions, dir, path);
-    if (value != null) {
-      if (value) {
-        value += "\n\n---\n\n";
-      }
-      const { mod, ver } = ctx.params;
-      value += `[doc](https://deno.land/${mod !== "std" ? "x/" : ""}${mod}${
-        ver !== "__latest__" ? `@${ver}` : ""
-      }${path}) | [source](${mod !== "std" ? "x/" : ""}${mod}${
-        ver !== "__latest__" ? `@${ver}` : ""
-      }${path}?source) | [info](${mod !== "std" ? "x/" : ""}${mod}${
-        ver !== "__latest__" ? `@${ver}` : ""
-      }/)`;
+    let value = await getPathDoc(completions, dir, path) ?? "";
+    if (value) {
+      value += "\n\n---\n\n";
     }
+    const { mod, ver } = ctx.params;
+    value += `[doc](https://deno.land/${mod !== "std" ? "x/" : ""}${mod}${
+      ver !== "__latest__" ? `@${ver}` : ""
+    }${path}) | [source](https://deno.land/${mod !== "std" ? "x/" : ""}${mod}${
+      ver !== "__latest__" ? `@${ver}` : ""
+    }${path}?source) | [info](https://deno.land/${
+      mod !== "std" ? "x/" : ""
+    }${mod}${ver !== "__latest__" ? `@${ver}` : ""}/)`;
     return Response.json({
       kind: "markdown",
       value,

--- a/main.ts
+++ b/main.ts
@@ -7,13 +7,16 @@
  */
 
 import { auth, type Context, Router } from "acorn";
+import { type SearchIndex } from "algoliasearch";
 import {
   type Datastore,
   DatastoreError,
   entityToObject,
 } from "google_datastore";
 import { errors, isHttpError } from "std/http/http_errors.ts";
+import twas from "twas";
 
+import { getSearchClient } from "./algolia.ts";
 import { endpointAuth, getDatastore } from "./auth.ts";
 import {
   cacheDocPage,
@@ -25,7 +28,8 @@ import {
   lookupLibDocPage,
   lookupSourcePage,
 } from "./cache.ts";
-import { kinds, ROOT_SYMBOL } from "./consts.ts";
+import { getCompletions, getPathDoc } from "./completions.ts";
+import { indexes, kinds, ROOT_SYMBOL } from "./consts.ts";
 import {
   checkMaybeLoad,
   type DocNode,
@@ -51,7 +55,7 @@ import {
   ModuleMetrics,
   SubModuleMetrics,
 } from "./types.d.ts";
-import { assert } from "./util.ts";
+import { assert, getPopularityLabel } from "./util.ts";
 
 interface PagedItems<T> {
   items: T[];
@@ -652,6 +656,172 @@ async function libDocPage(ctx: Context<unknown, LibDocPagesParams>) {
 }
 
 router.get("/v2/pages/lib/doc/:lib/:version{/}?", libDocPage);
+
+// registry completions
+
+export const MAX_AGE_1_HOUR = "max-age=3600";
+export const MAX_AGE_1_DAY = "max-age=86400";
+export const IMMUTABLE = "max-age=2628000, immutable";
+
+let searchIndex: SearchIndex | undefined;
+let cachedRootQuery: string[] | undefined;
+
+router.get("/completions/items/{:mod}?", async (ctx) => {
+  let items: string[] | undefined;
+  let isIncomplete = true;
+  if (ctx.params.mod || !cachedRootQuery) {
+    searchIndex = searchIndex ??
+      (await getSearchClient()).initIndex(indexes.MODULE_INDEX);
+    const res = await searchIndex.search<{ name: string }>(
+      ctx.params.mod ?? "",
+      {
+        facetFilters: "third_party:true",
+        hitsPerPage: 20,
+        attributesToRetrieve: ["name"],
+      },
+    );
+    isIncomplete = res.nbPages > 1;
+    items = res.hits.map(({ name }) => name);
+    if (!ctx.params.mod) {
+      cachedRootQuery = items;
+    }
+  } else if (!ctx.params.mod && cachedRootQuery) {
+    items = cachedRootQuery;
+  }
+  return Response.json({ items, isIncomplete }, {
+    headers: {
+      "cache-control": MAX_AGE_1_DAY,
+      "content-type": "application/json",
+    },
+  });
+});
+
+router.get("/completions/resolve/:mod", async (ctx) => {
+  const [moduleItem] = await lookup(ctx.params.mod);
+  if (moduleItem) {
+    const message = getPopularityLabel(moduleItem);
+    return Response.json({
+      kind: "markdown",
+      value:
+        `**${moduleItem.name}**\n\n${moduleItem.description}\n\n[info](https://deno.land/x/${moduleItem.name})${
+          message ? ` | ${message}` : ""
+        }\n\n`,
+    }, {
+      headers: {
+        "cache-control": MAX_AGE_1_DAY,
+        "content-type": "application/json",
+      },
+    });
+  }
+});
+
+router.get("/completions/items/:mod/{:ver}?", async (ctx) => {
+  const [moduleItem] = await lookup(ctx.params.mod);
+  if (moduleItem) {
+    const items = ctx.params.ver
+      ? moduleItem.versions.filter((version) =>
+        version.startsWith(ctx.params.ver)
+      )
+      : moduleItem.versions;
+    if (items.length) {
+      return Response.json({
+        items,
+        isIncomplete: false,
+        preselect:
+          moduleItem.latest_version && items.includes(moduleItem.latest_version)
+            ? moduleItem.latest_version
+            : undefined,
+      }, {
+        headers: {
+          "cache-control": MAX_AGE_1_HOUR,
+          "content-type": "application/json",
+        },
+      });
+    }
+  }
+});
+
+router.get("/completions/resolve/:mod/:ver", async (ctx) => {
+  const [moduleItem, moduleVersion] = await lookup(
+    ctx.params.mod,
+    ctx.params.ver,
+  );
+  if (moduleItem && moduleVersion) {
+    const message = getPopularityLabel(moduleItem);
+    const value =
+      `**${moduleVersion.name} @ ${moduleVersion.version}**\n\n${moduleVersion.description}\n\n[info](https://deno.land/x/${moduleVersion.name}@${moduleVersion.version}) | published: _${
+        twas(moduleVersion.uploaded_at)
+      }_${message ? ` | ${message}` : ""}\n\n`;
+    return Response.json({ kind: "markdown", value }, {
+      headers: {
+        "cache-control": MAX_AGE_1_DAY,
+        "content-type": "application/json",
+      },
+    });
+  }
+});
+
+router.get("/completions/items/:mod/:ver/:path*{/}?", async (ctx) => {
+  const completions = await getCompletions(ctx.params.mod, ctx.params.ver);
+  if (completions) {
+    const path = ctx.url().pathname.endsWith("/") && ctx.params.path
+      ? `/${ctx.params.path}/`
+      : `/${ctx.params.path}`;
+    const parts = path.split("/");
+    const last = parts.pop();
+    const dir = last ? `${parts.join("/")}/` : path;
+    const pathCompletion = completions.items.find(({ path }) => path === dir);
+    let preselect: string | undefined;
+    if (pathCompletion) {
+      const items: string[] = [];
+      let hasDir = false;
+      if (pathCompletion.dirs) {
+        for (const dir of pathCompletion.dirs) {
+          if (dir.startsWith(path)) {
+            hasDir = true;
+            items.push(dir);
+          }
+        }
+      }
+      for (const { path: mod } of pathCompletion.modules) {
+        if (mod.startsWith(path)) {
+          items.push(mod);
+        }
+      }
+      if (pathCompletion.default && items.includes(pathCompletion.default)) {
+        preselect = pathCompletion.default;
+      }
+      return Response.json({ items, preselect, isIncomplete: hasDir }, {
+        headers: {
+          "cache-control": IMMUTABLE,
+          "content-type": "application/json",
+        },
+      });
+    }
+  }
+});
+
+router.get("/completions/resolve/:mod/:ver/:path*{/}?", async (ctx) => {
+  const completions = await getCompletions(ctx.params.mod, ctx.params.ver);
+  if (completions) {
+    const path = ctx.url().pathname.endsWith("/") && ctx.params.path
+      ? `/${ctx.params.path}/`
+      : `/${ctx.params.path}`;
+    const parts = path.split("/");
+    const last = parts.pop();
+    const dir = last ? `${parts.join("/")}/` : path;
+    const value = await getPathDoc(completions, dir, path) ?? "";
+    return Response.json({
+      kind: "markdown",
+      value,
+    }, {
+      headers: {
+        "cache-control": IMMUTABLE,
+        "content-type": "application/json",
+      },
+    });
+  }
+});
 
 // webhooks
 

--- a/main.ts
+++ b/main.ts
@@ -789,9 +789,13 @@ router.get("/completions/items/:mod/:ver/:path*{/}?", async (ctx) => {
         }
       }
       if (pathCompletion.default && items.includes(pathCompletion.default)) {
-        preselect = pathCompletion.default;
+        preselect = pathCompletion.default.slice(1);
       }
-      return Response.json({ items, preselect, isIncomplete: hasDir }, {
+      return Response.json({
+        items: items.map((path) => path.slice(1)),
+        preselect,
+        isIncomplete: hasDir,
+      }, {
         headers: {
           "cache-control": IMMUTABLE,
           "content-type": "application/json",

--- a/specs/api-2.0.0.yaml
+++ b/specs/api-2.0.0.yaml
@@ -21,6 +21,8 @@ tags:
   description: Endpoints for rendering pages.
 - name: metrics
   description: Metric information.
+- name: completions
+  description: Endpoints for intelligent editor completions.
 - name: badges
   description: Endpoints providing badge information.
 - name: webhooks
@@ -28,6 +30,238 @@ tags:
 - name: infrastructure
   description: APIs that relate to internal infrastructure.
 paths:
+  /completions/items/{mod}:
+    get:
+      tags:
+        - completions
+      summary: Get module completion items.
+      description: >
+        Return a list of modules from the registry which can be imported.
+      operationId: getCompletionItemsMod
+      parameters:
+        - name: mod
+          in: path
+          description: The module name or search term
+          required: false
+          schema:
+            $ref: "#/components/schemas/ModuleName"
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompletionItems"
+        "404":
+          description: >
+            Not found - no resources for the given query were found. Try
+            changing the query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HttpError"
+            text/html:
+              schema:
+                type: string
+  /completions/items/{mod}/{ver}:
+    get:
+      tags:
+        - completions
+      summary: Get module version completion items.
+      description: >
+        Return a list of module versions from the registry which can be
+        imported.
+      operationId: getCompletionItemsModVer
+      parameters:
+        - name: mod
+          in: path
+          description: The module name
+          required: true
+          schema:
+            $ref: "#/components/schemas/ModuleName"
+        - name: ver
+          in: path
+          description: The version or partial version
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompletionItems"
+        "404":
+          description: >
+            Not found - no resources for the given query were found. Try
+            changing the query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HttpError"
+            text/html:
+              schema:
+                type: string
+  /completions/items/{mod}/{ver}/{path}:
+    get:
+      tags:
+        - completions
+      summary: Get path completion items.
+      description: >
+        Return a list of paths from the registry which can be
+        imported or directories which contain paths which can be imported.
+      operationId: getCompletionItemsPath
+      parameters:
+        - name: mod
+          in: path
+          description: The module name
+          required: true
+          schema:
+            $ref: "#/components/schemas/ModuleName"
+        - name: ver
+          in: path
+          description: The version or partial version
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: path
+          description: The path or partial path.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompletionItems"
+        "404":
+          description: >
+            Not found - no resources for the given query were found. Try
+            changing the query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HttpError"
+            text/html:
+              schema:
+                type: string
+  /completions/resolve/{mod}:
+    get:
+      tags:
+        - completions
+      summary: Get module completion docs.
+      description: Return documentation, if any, for a module.
+      operationId: getCompletionItemDocMod
+      parameters:
+        - name: mod
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/ModuleName"
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompletionItemDoc"
+        "404":
+          description: >
+            Not found - no resources for the given query were found. Try
+            changing the query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HttpError"
+            text/html:
+              schema:
+                type: string
+  /completions/resolve/{mod}/{ver}:
+    get:
+      tags:
+        - completions
+      summary: Get module completion docs.
+      description: Return documentation, if any, for a module.
+      operationId: getCompletionItemDocModVer
+      parameters:
+        - name: mod
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/ModuleName"
+        - name: ver
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompletionItemDoc"
+        "404":
+          description: >
+            Not found - no resources for the given query were found. Try
+            changing the query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HttpError"
+            text/html:
+              schema:
+                type: string
+  /completions/resolve/{mod}/{ver}/{path}:
+    get:
+      tags:
+        - completions
+      summary: Get documentation for a path.
+      description: >
+        If found, return any documentation associated with a path for display
+        in a client.
+      operationId: getCompletionItemDocPath
+      parameters:
+        - name: mod
+          in: path
+          description: The module name
+          required: true
+          schema:
+            $ref: "#/components/schemas/ModuleName"
+        - name: ver
+          in: path
+          description: The version or partial version
+          required: true
+          schema:
+            type: string
+        - name: path
+          in: path
+          description: The path or partial path.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompletionItemDoc"
+        "404":
+          description: >
+            Not found - no resources for the given query were found. Try
+            changing the query parameters.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HttpError"
+            text/html:
+              schema:
+                type: string
   /v2/metrics/apis:
     get:
       tags:
@@ -1218,6 +1452,33 @@ components:
       required:
         - "total"
         - "symbols"
+    CompletionItemDoc:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum:
+            - "markdown"
+            - "text"
+        value:
+          type: string
+      required:
+        - "kind"
+        - "value"
+    CompletionItems:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            type: string
+        isIncomplete:
+          type: boolean
+        preselect:
+          type: string
+      required:
+        - items
+        - isIncomplete
     DeclarationKind:
       type: string
       enum:

--- a/types.d.ts
+++ b/types.d.ts
@@ -466,6 +466,12 @@ export interface UsageMetric {
   sessions: number;
 }
 
+export interface CompletionItems {
+  items: string[];
+  isIncomplete: boolean;
+  preselect?: string;
+}
+
 export interface PathCompletion {
   path: string;
   default?: string;

--- a/types.d.ts
+++ b/types.d.ts
@@ -465,3 +465,16 @@ export interface UsageMetric {
   users: number;
   sessions: number;
 }
+
+export interface PathCompletion {
+  path: string;
+  default?: string;
+  dirs?: string[];
+  modules: { path: string; doc?: string }[];
+}
+
+export interface PathCompletions {
+  name: string;
+  version: string;
+  items: PathCompletion[];
+}

--- a/util.ts
+++ b/util.ts
@@ -1,5 +1,7 @@
 // Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
+import { type Module } from "./types.d.ts";
+
 export function assert(
   cond: unknown,
   message = "Assertion failed.",
@@ -7,4 +9,18 @@ export function assert(
   if (!cond) {
     throw new Error(message);
   }
+}
+
+/** Given a module, return a human readable string for the popularity. */
+export function getPopularityLabel(module: Module): string {
+  const popularity = module.tags?.find(({ kind }) => kind === "popularity");
+  switch (popularity?.value) {
+    case "top_1_percent":
+      return "⭐⭐⭐ Extremely Popular";
+    case "top_5_percent":
+      return "⭐⭐ Very Popular";
+    case "top_10_percent":
+      return "⭐ Popular";
+  }
+  return "";
 }


### PR DESCRIPTION
This adds the endpoints necessary to move the registry completions over to apiland.

It uses algolia for searching for modules and the information from the datastore for versions and entries.