### PR TITLE
feat: Adds IAM terraform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@ GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\
 GOOGLE_PRIVATE_KEY_ID=123456abcdefg
 GOOGLE_CLIENT_EMAIL=account@project-12345.iam.gserviceaccount.com
 
+# AWS
+MODERATION_BUCKET=somebucket
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=key_id
+AWS_SECRET_ACCESS_KEY=access_key
+
 # Algolia Credentials
 ALGOLIA_APP_ID=client_id
 ALGOLIA_API_KEY=api_key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
       GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}
       GOOGLE_PRIVATE_KEY_ID: ${{ secrets.GOOGLE_PRIVATE_KEY_ID }}
       GOOGLE_PROJECT_ID: ${{ secrets.GOOGLE_PROJECT_ID }}
+      MODERATION_BUCKET: ${{ secrets.MODERATION_BUCKET }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - name: ☑️ clone repository

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 /keys
 /docnodes
 /cache
+
+.terraform
+/terraform/*.tfplan
+/terraform/*.tfstate
+/terraform/*.tfvars

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.1.0"
+  hashes = [
+    "h1:iDyYmwv8q94Dvr4DRG1KBxTWPZRFkRmKGa3cjCEsPZU=",
+    "zh:0c48f157b804c1f392adb5c14b81e756c652755e358096300ea8dd1283021129",
+    "zh:1a50495a6c0e5665e51df57dac6e781ec71439b11ebf05f971b6f3a3eb4eb7b2",
+    "zh:2959ff472c05e56d59e012118dd8d55022f005534c0ae961ce81136de9f66a4d",
+    "zh:2dfda9133581b99ed6e709e89a453fd2974ce88c703d3e073ec31bf99d7508ce",
+    "zh:2f3d92cc7a6624da42cee2202f8fb23e6d38f156ab7851884d637282cb0dc709",
+    "zh:3bc2a34d09cbaf439a1815846904f070c782cd8dfd60b5e0116827cda25f7549",
+    "zh:4ef43f1a247aa8de8690ac3bbc2b00ebaf6b2872fc8d0f5130e4a8130c874b87",
+    "zh:5477cb272dcaeb0030091bcf23a9f0f33b5410e44e317e9d3d49446f545dbaa4",
+    "zh:734c8fb4c0b79c82dd757566761dda5b91ee1ef9a2b848a748ade11e0e1cc69f",
+    "zh:80346c051b677f4f018da7fe06318b87c5bd0f1ec67ce78ab33baed3bb8b031a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a865b2f88dfee13df14116c5cf53d033d2c15855f4b59b9c65337309a928df2c",
+    "zh:c0345f266eedaece5612c1000722b302f895d1bc5af1d5a4265f0e7000ca48bb",
+    "zh:d59703c8e6a9d8b4fbd3b4583b945dfff9cb2844c762c0b3990e1cef18282279",
+    "zh:d8d04a6a6cd2dfcb23b57e551db7b15e647f6166310fb7d883d8ec67bdc9bdc8",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.68.0"
+  hashes = [
+    "h1:VbNn940jp+svZjHw/smBbxUYO4XSwfLA2WgMwx9iiNw=",
+    "zh:094f4d7b5816c68a8b948fd363a435da4bc47ba3cc60fa5e6676dec296aaaf3e",
+    "zh:26a7fa7792eda30c8a411d71eeffa0cb4af45cb8d5eb6977fc01d880546c2ee7",
+    "zh:331270e22dd10911ba599803592203bc7b4dff7c40489a8ce8875e1a940de808",
+    "zh:4345c4359689db03ca9641e674761525d28bc4c01fe541f7e1e76af0e210cda3",
+    "zh:5208f5be9f2cdc60136566700630242462d38bb8abfa17ba4e25645dd42a0c19",
+    "zh:85aa3fa50a23842dde0144a39f7329656c8bb3a526aa9744ef1da88e0e284f2e",
+    "zh:b89ab408e1ad5932be1e9cfc5d4e554d067050fcc5903a9e268d4e19fb35677e",
+    "zh:c331adc2837e4f05047cdf79a36d48468e689658a7deae1aa3bbddfdee55e458",
+    "zh:ca121bcb1d640f8f8bec243227e9958bd78048ef0da5850618f542aa1ef0745b",
+    "zh:df352506473acdaddb4df120862ae144f238a93a2727511751d8a5baba88f7b2",
+    "zh:e48460d2a0fff75046255934026a7da6bdb058677feed3107105278d0baa032a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,0 +1,12 @@
+
+init:
+	terraform init -backend-config="bucket=denosr-apiland-terraform"
+
+plan:
+	terraform plan -var-file="apiland.tfvars" -out="apiland.tfplan"
+
+apply:
+	terraform apply apiland.tfplan
+
+pull-state:
+	terraform state pull > apiland.tfstate

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,63 @@
+
+
+
+resource "aws_iam_user" "apiland" {
+  name = "${var.environment}-apiland"
+  path = "/"
+
+  tags = {
+    managed-by = "denoland/apiland/terraform/main.tf"
+  }
+}
+
+// Policy taken from https://grafana.com/docs/grafana/latest/datasources/aws-apiland/#provision-the-data-source
+resource "aws_iam_user_policy" "apiland" {
+  name = "${var.environment}-apiland"
+  user = aws_iam_user.apiland.name
+
+
+// deno-registry2-prod-moderationbucket-b3a31d16
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SQSUserPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "sqs:GetQueueUrl",
+        "sqs:ListQueues",
+        "sqs:ReceiveMessage",
+        "sqs:SendMessage",
+        "sqs:SendMessageBatch",
+        "sqs:DeleteMessage",
+        "sqs:DeleteMessageBatch",
+        "sqs:GetQueueAttributes"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "S3UserPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::deno-registry2-prod-moderationbucket-b3a31d16",
+        "arn:aws:s3:::deno-registry2-prod-moderationbucket-b3a31d16/*", 
+        "arn:aws:s3:::deno-registry2-prod-storagebucket-replication-b3a31d16",
+        "arn:aws:s3:::deno-registry2-prod-storagebucket-replication-b3a31d16/*",
+        "arn:aws:s3:::deno-registry2-prod-storagebucket-b3a31d16",
+        "arn:aws:s3:::deno-registry2-prod-storagebucket-b3a31d16/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_access_key" "apiland" {
+  user = aws_iam_user.apiland.name
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,3 @@
-
-
-
 resource "aws_iam_user" "apiland" {
   name = "${var.environment}-apiland"
   path = "/"
@@ -15,8 +12,6 @@ resource "aws_iam_user_policy" "apiland" {
   name = "${var.environment}-apiland"
   user = aws_iam_user.apiland.name
 
-
-// deno-registry2-prod-moderationbucket-b3a31d16
   policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,8 +1,8 @@
 output "apiland_access_key_id" {
   value = aws_iam_access_key.apiland.id
 }
-  
+
 output "apiland_secret_key" {
-  value = aws_iam_access_key.apiland.secret
+  value     = aws_iam_access_key.apiland.secret
   sensitive = true
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,8 @@
+output "apiland_access_key_id" {
+  value = aws_iam_access_key.apiland.id
+}
+  
+output "apiland_secret_key" {
+  value = aws_iam_access_key.apiland.secret
+  sensitive = true
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+    backend "gcs" {
+        prefix = "terraform"
+    }
+}
+
+provider "aws" {
+  region = "us-east-1"
+  profile = "${var.aws_profile}"
+}
+
+provider "google" {
+  project = var.gcp_project
+}
+
+resource "google_storage_bucket" "terraform" {
+  name          = "denosr-apiland-terraform"
+  location      = "us"
+  force_destroy = false
+
+  versioning {
+    enabled = true
+  }
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,12 +1,12 @@
 terraform {
-    backend "gcs" {
-        prefix = "terraform"
-    }
+  backend "gcs" {
+    prefix = "terraform"
+  }
 }
 
 provider "aws" {
-  region = "us-east-1"
-  profile = "${var.aws_profile}"
+  region  = "us-east-1"
+  profile = var.aws_profile
 }
 
 provider "google" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,11 +1,11 @@
 
 variable "aws_profile" {
-  type = string
+  type    = string
   default = "default"
 }
 
 variable "environment" {
-  type = string
+  type    = string
   default = "prod"
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,15 @@
+
+variable "aws_profile" {
+  type = string
+  default = "default"
+}
+
+variable "environment" {
+  type = string
+  default = "prod"
+}
+
+variable "gcp_project" {
+  type = string
+}
+


### PR DESCRIPTION
We needed the ability for apiland to access SQS + S3 buckets, so here's an IAM user that can do both. At some point we'll want to pull in the S3 + SQS resources themselves, since the terraform that's managing them will likely go away. 